### PR TITLE
Feature/license update (#40)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,202 @@
-Copyright (c) 2020 V2C Development Team. All rights reserved.
-Licensed under the Version 0.0.1 of the V2C License (the "License").
-You may not use this file except in compliance with the License.
-You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions 
-limitations under the License.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+V2C Desktop Controller
+Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+All rights reserved.
+
+Some parts of this software were copied form, derived from, or inspired by
+the DFA Observer and Parser, written and developed by Caleb L. Power.
+
+Some parts of this software were copied from, derived from, or inspired by
+BoneMesh and other related software, is Axonibyte Innovations, LLC
+(https://axonibyte.com). Such software was released under the
+Apache License, Version 2.0, which can be obtained by visiting
+https://www.apache.org/licenses/LICENSE-2.0.html.

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ You can optionally specify some command-line arguments.
 
 ## License
 
-**This repository is subject to Version 0.0.1 of the [V2C License](https://tinyurl.com/v2c-license).**
+**This repository is subject to the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).**

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/V2CLinuxDesktopController.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/V2CLinuxDesktopController.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.desktop.linux;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/command/CommandParser.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/command/CommandParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.command;
 
 import edu.uco.cs.v2c.desktop.linux.model.ConfigurationData;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/command/ConfigParser.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/command/ConfigParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.command;
 
 import edu.uco.cs.v2c.desktop.linux.model.ConfigurationData;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/command/KeyboardRobot.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/command/KeyboardRobot.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.command;
 
 import java.awt.Robot;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/command/StateMachine.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/command/StateMachine.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.command;
 
 import java.util.LinkedList;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/command/TerminalCommandJava.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/command/TerminalCommandJava.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.command;
 
 public class TerminalCommandJava {

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/log/Logger.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/log/Logger.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.desktop.linux.log;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/Command.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/Command.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import edu.uco.cs.v2c.desktop.linux.command.TerminalCommandJava;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/CommandState.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/CommandState.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import java.awt.AWTException;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/ConfigurationData.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/ConfigurationData.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import org.json.JSONArray;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/Macro.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/Macro.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import edu.uco.cs.v2c.desktop.linux.command.KeyboardRobot;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/NewKeypress.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/NewKeypress.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import java.awt.event.KeyEvent;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/Numeric.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/Numeric.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import java.util.HashMap;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/RecognitionState.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/RecognitionState.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 public interface RecognitionState {

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/RecognitionStateContext.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/RecognitionStateContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 public class RecognitionStateContext {

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/StateKeypress.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/StateKeypress.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 // package edu.uco.cs.v2c.desktop.linux.model;
 
 // import java.awt.event.KeyEvent;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/StreamState.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/StreamState.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import edu.uco.cs.v2c.desktop.linux.dfaparser.Hypervisor;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/StreamStateKeypress.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/StreamStateKeypress.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import java.awt.event.KeyEvent;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/model/TypingState.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/model/TypingState.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.model;
 
 import edu.uco.cs.v2c.desktop.linux.dfaparser.Hypervisor;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/net/ConfigParser.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/net/ConfigParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.uco.cs.v2c.desktop.linux.net;
 
 import edu.uco.cs.v2c.dispatcher.api.listener.ConfigUpdateListener;

--- a/src/main/java/edu/uco/cs/v2c/desktop/linux/net/DispatcherHandler.java
+++ b/src/main/java/edu/uco/cs/v2c/desktop/linux/net/DispatcherHandler.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.desktop.linux.net;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/DispatcherConnection.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/DispatcherConnection.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/CommandListener.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/CommandListener.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.listener;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/ConfigUpdateListener.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/ConfigUpdateListener.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.listener;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/ConnectionCloseListener.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/ConnectionCloseListener.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.listener;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/ConnectionOpenListener.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/ConnectionOpenListener.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.listener;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/HeartbeatListener.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/HeartbeatListener.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.listener;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/MessageListener.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/MessageListener.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.listener;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/WebSocketErrorListener.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/listener/WebSocketErrorListener.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.listener;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/MalformedPayloadException.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/MalformedPayloadException.java
@@ -1,25 +1,13 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Original code copyright (c) 2020 Axonibyte Innovations,
+ * LLC. All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
- * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
- * THIS FILE HAS BEEN MODIFIED. ORIGINAL WORK ADHERES TO THE FOLLOWING NOTICE.
- * 
- * Copyright (c) 2020 Axonibyte Innovations, LLC. All rights reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/PayloadHandlingException.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/PayloadHandlingException.java
@@ -1,25 +1,13 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Original code copyright (c) 2020 Axonibyte Innovations,
+ * LLC. All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
- * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
- * THIS FILE HAS BEEN MODIFIED. ORIGINAL WORK ADHERES TO THE FOLLOWING NOTICE.
- * 
- * Copyright (c) 2020 Axonibyte Innovations, LLC. All rights reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/ErrorPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/ErrorPayload.java
@@ -1,25 +1,13 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Original code copyright (c) 2020 Axonibyte Innovations,
+ * LLC. All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
- * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
- * THIS FILE HAS BEEN MODIFIED. ORIGINAL WORK ADHERES TO THE FOLLOWING NOTICE.
- * 
- * Copyright (c) 2020 Axonibyte Innovations, LLC. All rights reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/HeartbeatPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/HeartbeatPayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.incoming;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/InboundConfigUpdatePayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/InboundConfigUpdatePayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.incoming;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/IncomingPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/IncomingPayload.java
@@ -1,25 +1,13 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Original code copyright (c) 2020 Axonibyte Innovations,
+ * LLC. All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
- * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
- * THIS FILE HAS BEEN MODIFIED. ORIGINAL WORK ADHERES TO THE FOLLOWING NOTICE.
- * 
- * Copyright (c) 2020 Axonibyte Innovations, LLC. All rights reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/RouteCommandPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/RouteCommandPayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.incoming;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/RouteMessagePayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/incoming/RouteMessagePayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.incoming;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/DeregisterListenerPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/DeregisterListenerPayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.outgoing;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/DispatchCommandPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/DispatchCommandPayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.outgoing;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/DispatchMessagePayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/DispatchMessagePayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.outgoing;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/HeartbeatAckPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/HeartbeatAckPayload.java
@@ -1,13 +1,17 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Original code copyright (c) 2020 Axonibyte Innovations,
+ * LLC. All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.outgoing;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/OutboundConfigUpdatePayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/OutboundConfigUpdatePayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.outgoing;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/OutgoingPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/OutgoingPayload.java
@@ -1,25 +1,13 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Original code copyright (c) 2020 Axonibyte Innovations,
+ * LLC. All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
- * limitations under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
- * THIS FILE HAS BEEN MODIFIED. ORIGINAL WORK ADHERES TO THE FOLLOWING NOTICE.
- * 
- * Copyright (c) 2020 Axonibyte Innovations, LLC. All rights reserved.
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/RegisterConfigurationPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/RegisterConfigurationPayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.outgoing;

--- a/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/RegisterListenerPayload.java
+++ b/src/main/java/edu/uco/cs/v2c/dispatcher/api/payload/outgoing/RegisterListenerPayload.java
@@ -1,13 +1,16 @@
 /*
- * Copyright (c) 2020 V2C Development Team. All rights reserved.
- * Licensed under the Version 0.0.1 of the V2C License (the "License").
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at <https://tinyurl.com/v2c-license>.
+ * Copyright (c) 2020 Caleb L. Power, Everistus Akpabio, Rashed Alrashed,
+ * Nicholas Clemmons, Jonathan Craig, James Cole Riggall, and Glen Mathew.
+ * All rights reserved. Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package edu.uco.cs.v2c.dispatcher.api.payload.outgoing;


### PR DESCRIPTION
* fast-forward dispatcher API to meet Council desires wrt licensing
* updated license to Apache 2.0 in accordance with the wishes of the Council.
* updated README to reflect license change